### PR TITLE
Add resume content to personal site

### DIFF
--- a/_config.yml
+++ b/_config.yml
@@ -9,40 +9,34 @@ theme: jekyll-theme-chirpy
 lang: en
 
 # Change to your timezone › https://kevinnovak.github.io/Time-Zone-Picker
-timezone:
+timezone: America/New_York
 
 # jekyll-seo-tag settings › https://github.com/jekyll/jekyll-seo-tag/blob/master/docs/usage.md
 # ↓ --------------------------
 
-title: Chirpy # the main title
+title: "Pinyuan Li" # the main title
 
-tagline: A text-focused Jekyll theme # it will display as the subtitle
+tagline: "Machine Learning Researcher & Software Developer" # it will display as the subtitle
 
 description: >- # used by seo meta and the atom feed
-  A minimal, responsive and feature-rich Jekyll theme for technical writing.
+  Personal site of Pinyuan Li, sharing research projects and software development notes.
 
 # Fill in the protocol & hostname for your site.
 # E.g. 'https://username.github.io', note that it does not end with a '/'.
 url: ""
 
 github:
-  username: github_username # change to your GitHub username
+  username: BrandeisPatrick
 
 twitter:
-  username: twitter_username # change to your Twitter username
+  username: ""
 
 social:
-  # Change to your full name.
-  # It will be displayed as the default author of the posts and the copyright owner in the Footer
-  name: your_full_name
-  email: example@domain.com # change to your email address
+  name: Pinyuan Li
+  email: EmoryPatrick@outlook.com
   links:
-    # The first element serves as the copyright owner's link
-    - https://twitter.com/username # change to your Twitter homepage
-    - https://github.com/username # change to your GitHub homepage
-    # Uncomment below to add more social links
-    # - https://www.facebook.com/username
-    # - https://www.linkedin.com/in/username
+    - https://github.com/BrandeisPatrick
+    - https://linkedin.com/in/PatrickLi
 
 # Site Verification Settings
 webmaster_verifications:

--- a/_data/contact.yml
+++ b/_data/contact.yml
@@ -3,8 +3,6 @@
 - type: github
   icon: "fab fa-github"
 
-- type: twitter
-  icon: "fa-brands fa-x-twitter"
 
 - type: email
   icon: "fas fa-envelope"
@@ -14,6 +12,9 @@
   icon: "fas fa-rss"
   noblank: true
 # Uncomment and complete the url below to enable more contact options
+- type: linkedin
+  icon: "fab fa-linkedin"
+  url: "https://linkedin.com/in/PatrickLi"
 #
 # - type: mastodon
 #   icon: 'fab fa-mastodon'   # icons powered by <https://fontawesome.com/>

--- a/_tabs/about.md
+++ b/_tabs/about.md
@@ -4,5 +4,71 @@ icon: fas fa-info-circle
 order: 4
 ---
 
-> Add Markdown syntax content to file `_tabs/about.md`{: .filepath } and it will show up on this page.
-{: .prompt-tip }
+# Pinyuan Li
+
+Machine Learning Researcher & Software Developer @ Emory
+
+📧 [EmoryPatrick@outlook.com](mailto:EmoryPatrick@outlook.com)
+🔗 [LinkedIn](https://linkedin.com/in/PatrickLi)
+🖥 [GitHub](https://github.com/BrandeisPatrick)
+
+## Skills
+
+- BERT, Large Language Model (LLM), Diffusion Models, Contrastive Learning
+- Python, Java, C
+- Software Development, Algorithm Design, Statistical Modeling
+- Data Visualization, Computer Cluster Management, Parallel Computing
+- Job Scheduling with SLURM, Google Cloud Platform (GCP), Amazon Web Services (AWS)
+- Weights & Biases, TensorBoard, Scikit-Learn
+
+## Work Experience
+
+### Emory University, Bromberg Lab — Machine Learning Researcher
+*Jun 2024 – Present*
+- Led a National Science Foundation-funded AI4Science project, developing reliable machine-learning solutions for complex biological problems.
+- Built scalable algorithms and implemented machine learning models to help LLMs better understand biology domain data.
+- Worked with fellow researchers to improve explainable AI for foundational biological models, including AlphaFold by analyzing self-attention maps.
+
+### Emory University, Fang Lab — Machine Learning Researcher
+*Sep 2021 – Present*
+- Collaborated with a multidisciplinary team to design and implement machine learning solutions that utilize chemical features, resulting in improved model performance for chemistry applications.
+- Developed a curated dataset of 10,000 chemical compounds with handcrafted features, optimized for AI-driven chemistry models. It received 10 citations within the first year.
+
+### Brandeis University, Herzfeld Lab — Undergraduate Software Developer
+*Aug 2019 – Aug 2021*
+- Co-developed LEWIS, a semi-classical force field simulation tool in C, enabling accurate simulation and prediction of molecular dynamics.
+- Managed the complete software lifecycle—including development, deployment, maintenance, and updates—to ensure consistent performance and reliability.
+
+## Selected Projects
+
+### Protein Siamese Neural Network: Predicting Single Nucleotide Variant Effects
+- Engineered and optimized deep learning models using contrastive learning for high-performance text semantic similarity detection for protein sequence data.
+- Built a data pipeline to process a 100K-entry dataset efficiently.
+- Developed a classification model inspired by NLP-based text similarity techniques, improving mutation effect prediction accuracy by 7% over the baseline model.
+- Developed automated training pipelines with experiment tracking and gradient visualization.
+- Published well-documented, modular code on GitHub, ensuring collaborative development and maintainability.
+
+### Learning Protein-ish: Foundational Insights on Protein Language Models
+- Designed and deployed a domain-specific LLM, leveraging Hugging Face, PyTorch, and scikit-learn, optimizing biological sequence interpretation.
+- Built a pipeline to scrape, clean, and filter a 100K-entry dataset from UniProt using Python and SQL, refining it into a high-quality 10K dataset.
+- Conducted an architectural analysis of state-of-the-art LLMs, evaluating their efficiency, scalability, and real-world applications.
+- Used adversarial probing techniques to analyze attention mechanisms in LLMs, improving interpretability for protein-sequence prediction.
+- Benchmarked models using accuracy, F1-score, and AUC-ROC, optimizing for performance and efficiency.
+- Deployed the LLM on Google Cloud Platform under the Google Cloud Research Credits Program, ensuring scalability and cloud-based accessibility.
+
+### LEWIS: Semi-Classical Molecular Force Field Software
+- Developed a high-performance molecular simulation engine in C, optimizing semi-classical force field parameters for enhanced computational chemistry.
+- Implemented Differential Evolution and Monte Carlo methods for parameter optimization, achieving a 50% improvement in computational speed over state-of-the-art approaches.
+
+## Education
+
+- **Emory University**, Master’s in Computational Chemistry (Sep 2021 – Present)  
+  Co-advisors: Fang Liu (Chemistry), Yana Bromberg (Biology), and Joyce Ho (Computer Science)
+- **Brandeis University**, Bachelor of Science in Biochemistry (Jan 2019 – May 2021)  
+  Transferred from Michigan State University in 2019
+- **Michigan State University**, Bachelor of Science in Physics (Sep 2017 – Jan 2019)
+
+## Awards
+
+Brandeis Provost’s Undergraduate Research Fellowship, Google Cloud Research Credits Recipient, Michigan State Honors College, Michigan State Advanced Mathematics Track Program.
+


### PR DESCRIPTION
## Summary
- update About tab with resume details
- configure personal information in `_config.yml`
- add LinkedIn contact link

## Testing
- `bundle install` *(fails: 403 Forbidden)*

------
https://chatgpt.com/codex/tasks/task_e_6874824f9cc08321b75620e71ad43f61