### PR TITLE
feat: display average rank for teams

### DIFF
--- a/_data/teams.yml
+++ b/_data/teams.yml
@@ -1,0 +1,13 @@
+teams:
+  - name: Team 1
+    members:
+      - name: Alice
+        rank: 1
+      - name: Bob
+        rank: 3
+  - name: Team 2
+    members:
+      - name: Carol
+        rank: 2
+      - name: Dave
+        rank: 4

--- a/_tabs/team-rankings.md
+++ b/_tabs/team-rankings.md
@@ -1,0 +1,27 @@
+---
+layout: page
+title: Team Rankings
+icon: fas fa-trophy
+order: 6
+excerpt: ""
+---
+
+{% for team in site.data.teams.teams %}
+  {% assign total = 0 %}
+  {% for member in team.members %}
+    {% assign total = total | plus: member.rank %}
+  {% endfor %}
+  {% assign count = team.members | size %}
+  {% assign avg = total | plus: 0.0 | divided_by: count %}
+
+### {{ team.name }}
+
+| Member | Rank |
+|--------|------|
+{% for member in team.members %}
+| {{ member.name }} | {{ member.rank }} |
+{% endfor %}
+
+**Average Rank:** {{ avg | round: 2 }}
+
+{% endfor %}


### PR DESCRIPTION
## Summary
- add team ranking data for two teams
- render team ranking tab with average rank calculation

## Testing
- `bash tools/test.sh`

------
https://chatgpt.com/codex/tasks/task_e_689236f35c3c8321ba34ae2431b041e1