### PR TITLE
Add sidebar with placeholder stat tabs

### DIFF
--- a/assets/css/jekyll-theme-chirpy.scss
+++ b/assets/css/jekyll-theme-chirpy.scss
@@ -43,3 +43,31 @@
   background-color: var(--timeline-node-bg);
   border: 3px solid var(--timeline-year-dot-color);
 }
+
+/* Custom sidebar */
+#custom-sidebar {
+  position: fixed;
+  top: 4rem;
+  right: 0;
+  width: 200px;
+  background-color: var(--sidebar-bg, #f7f7f7);
+  border-left: 1px solid #ccc;
+  padding: 1rem;
+  z-index: 1000;
+}
+
+#custom-sidebar .sidebar-tabs {
+  list-style: none;
+  margin: 0;
+  padding: 0;
+}
+
+#custom-sidebar .sidebar-tabs li {
+  margin-bottom: 0.5rem;
+}
+
+#custom-sidebar .sidebar-tabs a {
+  text-decoration: none;
+  color: inherit;
+}
+

--- a/index.html
+++ b/index.html
@@ -2,3 +2,11 @@
 layout: home
 # Index page
 ---
+
+<div id="custom-sidebar">
+  <ul class="sidebar-tabs">
+    <li><a href="#">Stats</a></li>
+    <li><a href="#">Hero Stats</a></li>
+  </ul>
+</div>
+


### PR DESCRIPTION
## Summary
- add a fixed sidebar on the home page
- add placeholder tabs for Stats and Hero Stats

## Testing
- `bash tools/test.sh`

------
https://chatgpt.com/codex/tasks/task_e_6894bc82c4688321b6c1120fbe2b8bea