### PR TITLE
Revert to commit cd44a6f and remove sidebar placeholder

### DIFF
--- a/assets/css/jekyll-theme-chirpy.scss
+++ b/assets/css/jekyll-theme-chirpy.scss
@@ -43,31 +43,3 @@
   background-color: var(--timeline-node-bg);
   border: 3px solid var(--timeline-year-dot-color);
 }
-
-/* Custom sidebar */
-#custom-sidebar {
-  position: fixed;
-  top: 4rem;
-  right: 0;
-  width: 200px;
-  background-color: var(--sidebar-bg, #f7f7f7);
-  border-left: 1px solid #ccc;
-  padding: 1rem;
-  z-index: 1000;
-}
-
-#custom-sidebar .sidebar-tabs {
-  list-style: none;
-  margin: 0;
-  padding: 0;
-}
-
-#custom-sidebar .sidebar-tabs li {
-  margin-bottom: 0.5rem;
-}
-
-#custom-sidebar .sidebar-tabs a {
-  text-decoration: none;
-  color: inherit;
-}
-

--- a/index.html
+++ b/index.html
@@ -2,11 +2,3 @@
 layout: home
 # Index page
 ---
-
-<div id="custom-sidebar">
-  <ul class="sidebar-tabs">
-    <li><a href="#">Stats</a></li>
-    <li><a href="#">Hero Stats</a></li>
-  </ul>
-</div>
-


### PR DESCRIPTION
## Summary
- Revert merge commit that added sidebar with placeholder stat tabs
- Restore `assets/css/jekyll-theme-chirpy.scss` and `index.html` to state of commit `cd44a6f`

## Testing
- `bundle install`
- `bundle exec jekyll build`


------
https://chatgpt.com/codex/tasks/task_e_68953c921d3c8321a8024e291cc144dc