### PR TITLE
Improve sidebar icon visibility

### DIFF
--- a/assets/css/jekyll-theme-chirpy.scss
+++ b/assets/css/jekyll-theme-chirpy.scss
@@ -43,3 +43,26 @@
   background-color: var(--timeline-node-bg);
   border: 3px solid var(--timeline-year-dot-color);
 }
+
+/* Sidebar visibility improvements */
+#sidebar .nav-link {
+  display: flex;
+  align-items: center;
+}
+
+#sidebar .nav-link i {
+  margin-right: 0.5rem;
+}
+
+#sidebar .sidebar-bottom {
+  gap: 0.5rem;
+  justify-content: center;
+}
+
+#sidebar .sidebar-bottom a,
+#sidebar .sidebar-bottom button {
+  color: inherit;
+  opacity: 1;
+  font-size: 1.2rem;
+}
+


### PR DESCRIPTION
## Summary
- improve sidebar icon spacing and layout
- ensure bottom icons use inherited color and visible sizes

## Testing
- `bundle exec jekyll build`

------
https://chatgpt.com/codex/tasks/task_e_6898349a17f88321a5985d0bf8974128